### PR TITLE
Fix for the container.json["fields"] issue.

### DIFF
--- a/to-share.py
+++ b/to-share.py
@@ -230,7 +230,7 @@ def field_to_share(field):
 # Finds the child fields of a form / container field
 def get_child_fields(container):
    if isinstance(container,Form):
-      return container.json["fields"]
+      return container.json["editorJson"]["fields"] # Recent acitiviti export has been changed their JSON structure for the fields. Now "fields" are inside "editorJson"
    fields = []
    if container.get("fieldType","") == "ContainerRepresentation":
       for f in container["fields"]:


### PR DESCRIPTION
File "to-share.py", line 233, in get_child_fields
    return container.json["fields"]
KeyError: 'fields'

**Previous  JSON structure for the activiti-form fields:**

```
{
    "tabs":[],
    "fields":[],
    "outcomes":[{}],
    "customFieldTemplates":{},
    "gridsterForm":false
} 
```

**New or current JSON structure for the activiti-form fields:**

``````
{
    "referenceId":980001,
    "name":"Assignee Task form 3-3",
    "description":"",
    "editorJson":{
        "tabs":[],
        "fields":[],
        "outcomes":[],
        "javascriptEvents":[],
        "customFieldTemplates":{},
        "gridsterForm":false
    }
} ```
``````
