### PR TITLE
Fix for outcome properties issue

### DIFF
--- a/to-share.py
+++ b/to-share.py
@@ -230,7 +230,7 @@ def field_to_share(field):
 # Finds the child fields of a form / container field
 def get_child_fields(container):
    if isinstance(container,Form):
-      return container.json["fields"]
+      return container.json["editorJson"]["fields"] # Recent acitiviti export has been changed their JSON structure for the fields. Now "fields" are inside "editorJson"
    fields = []
    if container.get("fieldType","") == "ContainerRepresentation":
       for f in container["fields"]:

--- a/to-share.py
+++ b/to-share.py
@@ -382,8 +382,9 @@ for form in forms:
 
    # Process as a type
    model.start_type(form)
-   handle_fields(get_child_fields(form), share_form)
-   handle_outcomes(form.json.get("outcomes",[]), form, share_form)
+   handle_fields(get_child_fields(form), share_form) 
+   # Read the outcome property values form JSON.
+   handle_outcomes(form.json["editorJson"].get("outcomes",[]), form, share_form)
    model.end_type(form)
 
    # Do the Share Config conversion + output

--- a/to-share.py
+++ b/to-share.py
@@ -211,7 +211,11 @@ def field_to_share(field):
    if ftype == "readonly-text":
        appearance += "  <control template=\"/org/alfresco/components/form/controls/readonly.ftl\">\n"
        appearance += "    <control-param name=\"value\">%s</control-param>\n" % field.get("value","")
-       appearance += "  </control>\n"
+       appearance += "  </control>\n"   
+   if ftype == "multi-line-text":
+       appearance += "  <control template=\"/org/alfresco/components/form/controls/textarea.ftl\">\n"
+       appearance += "    <control-param name=\"value\">%s</control-param>\n" % field.get("value","")
+       appearance += "  </control>\n"       
    if ftype in ("radio-buttons","dropdown") and options:
        appearance += "  <control template=\"/org/alfresco/components/form/controls/selectone.ftl\">\n"
        appearance += "    <control-param name=\"options\">%s</control-param>\n" % ",".join([o["name"] for o in options])


### PR DESCRIPTION
Activiti online exporter has changed their export format and I fixed it here.
Use this, `handle_outcomes(form.json["editorJson"].get("outcomes",[]),``form, share_form)`
